### PR TITLE
Fix bugs in src/href attrib and relative protocol matching

### DIFF
--- a/tasks/combo_html_css_js.js
+++ b/tasks/combo_html_css_js.js
@@ -23,20 +23,20 @@ module.exports = function (grunt) {
    * @return {string}
    */
   function combo(filepath) {
-    var cssHrefPattern = /<link(?:[^>]*) href="(.+)"(?:[^>]*)>/g;
-    var jsSrcPattern = /<script(?:[^>]*) src="(.+)"(?:[^>]*)>/g;
+    var cssHrefPattern = /<link(?:[^>]*) href="([^"]+)"(?:[^>]*)>/g;
+    var jsSrcPattern = /<script(?:[^>]*) src="([^"]+)"(?:[^>]*)>/g;
 
     var html = grunt.file.read(filepath);
 
     html = html.replace(cssHrefPattern, function (openTag, href) {
-      if (href.match(/\:/)) {
+      if (href.match(/\/\//)) {
         return openTag;
       }
       return '<style>\n' + grunt.file.read(path.join(filepath, '../', href)) + '\n</style>';
     });
 
     html = html.replace(jsSrcPattern, function (openTag, src) {
-      if (src.match(/\:/)) {
+      if (src.match(/\/\//)) {
         return openTag;
       }
       return '<script>\n' + grunt.file.read(path.join(filepath, '../', src)) + '\n';


### PR DESCRIPTION
Hi, this PR fixes:
- when `<script>` or `<link>` tag lines have another set of "> characters on same line the filename will contain everything to the last ">,
- if href/src had a relative protocol (no http or https just starts with //) it thought it was a file
